### PR TITLE
s1p-tickets-service-giraffe to 0.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 0.0.28
 - name: s1p-tickets-service-giraffe
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.2
+  version: 0.0.3
 - name: showcase-admin-tool
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.56


### PR DESCRIPTION
Promote s1p-tickets-service-giraffe to version 0.0.3